### PR TITLE
Allow http hub keys

### DIFF
--- a/bass/__init__.py
+++ b/bass/__init__.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 
 # Copyright 2016 Open Permissions Platform Coalition
-# Licensed under the Apache License, Version 2.0 (the "License"); 
+# Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License. You may obtain a copy of the License at
 # http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software distributed under the License is 
-# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+# Unless required by applicable law or agreed to in writing, software distributed under the License is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-__version__ = '1.0.9'
+__version__ = '1.0.10'

--- a/bass/hubkey.py
+++ b/bass/hubkey.py
@@ -37,7 +37,7 @@ UUID = r'[0-9a-f]{1,64}' # < relaxed definition (useful for fake ids used in tes
 # 63 characters. Each label must be separated with a period.
 # See RFC1123 & RFC952
 # The hub_id may optionally contain a port, e.g. localhost:8000
-RESOLVER_ID = r'{protocol}://{label}(?:\.{label})*{port}?'.format(
+RESOLVER_ID = r'{protocol}?://{label}(?:\.{label})*{port}?'.format(
     protocol=PROTOCOL, label=_HOST_LABEL, port=_PORT)
 
 PARTS = OrderedDict([


### PR DESCRIPTION
Required for vagrant where the services are using HTTP within the VM